### PR TITLE
fix x64 arch warnings

### DIFF
--- a/MXLCalendarManager/MXLCalendarEvent.m
+++ b/MXLCalendarManager/MXLCalendarEvent.m
@@ -290,8 +290,8 @@
     NSInteger dayOfYear = [calendar ordinalityOfUnit:NSCalendarUnitDay inUnit:NSCalendarUnitYear forDate:date];
 
     NSString *dayString = [self dayOfWeekFromInteger:components.weekday];
-    NSString *weekNumberString  = [NSString stringWithFormat:@"%i", [components weekOfYear]];
-    NSString *monthString = [NSString stringWithFormat:@"%i", m];
+    NSString *weekNumberString  = [NSString stringWithFormat:@"%li", (long)[components weekOfYear]];
+    NSString *monthString = [NSString stringWithFormat:@"%li", (long)m];
     
     // If the event is set to repeat on a certain day of the week,
     // it MUST be the current date's weekday for it to occur
@@ -308,10 +308,10 @@
     }
     
     // Same as above (and below)
-    if (repeatRuleByMonthDay && ![repeatRuleByMonthDay containsObject:[NSString stringWithFormat:@"%i", d]])
+    if (repeatRuleByMonthDay && ![repeatRuleByMonthDay containsObject:[NSString stringWithFormat:@"%li", (long)d]])
         return NO;
     
-    if (repeatRuleByYearDay && ![repeatRuleByYearDay containsObject:[NSString stringWithFormat:@"%i", dayOfYear]])
+    if (repeatRuleByYearDay && ![repeatRuleByYearDay containsObject:[NSString stringWithFormat:@"%li", (long)dayOfYear]])
         return NO;
     
     if (repeatRuleByWeekNo && ![repeatRuleByWeekNo containsObject:weekNumberString])
@@ -492,8 +492,8 @@
     NSInteger dayOfYear = [calendar ordinalityOfUnit:NSCalendarUnitDay inUnit:NSCalendarUnitYear forDate:date];
     
     NSString *dayString = [self dayOfWeekFromInteger:components.weekday];
-    NSString *weekNumberString  = [NSString stringWithFormat:@"%i", [components weekOfYear]];
-    NSString *monthString = [NSString stringWithFormat:@"%i", m];
+    NSString *weekNumberString  = [NSString stringWithFormat:@"%li", (long)[components weekOfYear]];
+    NSString *monthString = [NSString stringWithFormat:@"%li", (long)m];
     
     // If the event is set to repeat on a certain day of the week,
     // it MUST be the current date's weekday for it to occur
@@ -510,10 +510,10 @@
     }
     
     // Same as above (and below)
-    if (exRuleByMonthDay && ![exRuleByMonthDay containsObject:[NSString stringWithFormat:@"%i", d]])
+    if (exRuleByMonthDay && ![exRuleByMonthDay containsObject:[NSString stringWithFormat:@"%li", (long)d]])
         return NO;
     
-    if (exRuleByYearDay && ![exRuleByYearDay containsObject:[NSString stringWithFormat:@"%i", dayOfYear]])
+    if (exRuleByYearDay && ![exRuleByYearDay containsObject:[NSString stringWithFormat:@"%li", (long)dayOfYear]])
         return NO;
     
     if (exRuleByWeekNo && ![exRuleByWeekNo containsObject:weekNumberString])


### PR DESCRIPTION
NSInteger is defined as long and is a 64-bit integer. The %i format, on the other hand, is for int, which is 32-bit. So the format and the actual parameter do not match in size.

Since NSInteger is 32-bit or 64-bit, depending on the platform, the compiler recommends to add a cast to long generally. (c) Martin R

and that's what i did
