### PR TITLE
Added duration support

### DIFF
--- a/MXLCalendarManager/MXLCalendarEvent.h
+++ b/MXLCalendarManager/MXLCalendarEvent.h
@@ -89,7 +89,7 @@ typedef enum {
 
 @property (strong, nonatomic) NSString *rruleString;
 
--(id)initWithStartDate:(NSString *)startString endDate:(NSString *)endString createdAt:(NSString *)createdString lastModified:(NSString *)lastModifiedString uniqueID:(NSString *)uniqueID recurrenceID:(NSString *)recurrenceID summary:(NSString *)summary description:(NSString *)description location:(NSString *)location status:(NSString *)status recurrenceRules:(NSString *)recurRules exceptionDates:(NSMutableArray *)exceptionDates exceptionRule:(NSString *)exceptionRule timeZoneIdentifier:(NSString *)timezoneID;
+-(id)initWithStartDate:(NSString *)startString duration:(NSString *)durationString endDate:(NSString *)endString createdAt:(NSString *)createdString lastModified:(NSString *)lastModifiedString uniqueID:(NSString *)uniqueID recurrenceID:(NSString *)recurrenceID summary:(NSString *)summary description:(NSString *)description location:(NSString *)location status:(NSString *)status recurrenceRules:(NSString *)recurRules exceptionDates:(NSMutableArray *)exceptionDates exceptionRule:(NSString *)exceptionRule timeZoneIdentifier:(NSString *)timezoneID;
 
 -(NSDate *)dateFromString:(NSString *)dateString;
 

--- a/MXLCalendarManager/MXLCalendarEvent.m
+++ b/MXLCalendarManager/MXLCalendarEvent.m
@@ -27,6 +27,7 @@
 
 #import "MXLCalendarEvent.h"
 #import <EventKit/EventKit.h>
+#import "NSDateComponents+ISO8601Duration.h"
 
 #define DAILY_FREQUENCY @"DAILY"
 #define WEEKLY_FREQUENCY @"WEEKLY"
@@ -41,7 +42,7 @@
 
 @implementation MXLCalendarEvent
 
--(id)initWithStartDate:(NSString *)startString endDate:(NSString *)endString createdAt:(NSString *)createdString lastModified:(NSString *)lastModifiedString uniqueID:(NSString *)uniqueID recurrenceID:(NSString *)recurrenceID summary:(NSString *)summary description:(NSString *)description location:(NSString *)location status:(NSString *)status recurrenceRules:(NSString *)recurRules exceptionDates:(NSMutableArray *)exceptionDates exceptionRule:(NSString *)exceptionRule timeZoneIdentifier:(NSString *)timezoneID {
+-(id)initWithStartDate:(NSString *)startString duration:(NSString *)durationString endDate:(NSString *)endString createdAt:(NSString *)createdString lastModified:(NSString *)lastModifiedString uniqueID:(NSString *)uniqueID recurrenceID:(NSString *)recurrenceID summary:(NSString *)summary description:(NSString *)description location:(NSString *)location status:(NSString *)status recurrenceRules:(NSString *)recurRules exceptionDates:(NSMutableArray *)exceptionDates exceptionRule:(NSString *)exceptionRule timeZoneIdentifier:(NSString *)timezoneID {
     
     self = [super self];
 
@@ -58,6 +59,10 @@
         self.eventStartDate = [self dateFromString:startString];
         
         self.eventEndDate   = [self dateFromString:endString];
+        if (durationString && !self.eventEndDate && self.eventStartDate) {
+            NSDateComponents *components = [NSDateComponents durationFrom8601String:durationString];
+            self.eventEndDate = [[NSCalendar currentCalendar] dateByAddingComponents:components toDate:self.eventStartDate options:0];
+        }
         self.eventCreatedDate = [self dateFromString:createdString];
         self.eventLastModifiedDate = [self dateFromString:lastModifiedString];
         

--- a/MXLCalendarManager/MXLCalendarManager.m
+++ b/MXLCalendarManager/MXLCalendarManager.m
@@ -97,6 +97,7 @@
     for (NSString *event in eventsArray) {
         NSString *timezoneIDString;
         NSString *startDateTimeString;
+        NSString *durationString;
         NSString *endDateTimeString;
         NSString *eventUniqueIDString;
         NSString *recurrenceIDString;
@@ -131,6 +132,12 @@
             [eventScanner scanUpToString:@"\n" intoString:&startDateTimeString];
             startDateTimeString = [[startDateTimeString stringByReplacingOccurrencesOfString:@"DTSTART:" withString:@""] stringByReplacingOccurrencesOfString:@"\r" withString:@""];
         }
+        
+        // Extract duration
+        eventScanner = [NSScanner scannerWithString:event];
+        [eventScanner scanUpToString:@"DURATION" intoString:nil];
+        [eventScanner scanUpToString:@"\n" intoString:&durationString];
+        durationString = [[durationString stringByReplacingOccurrencesOfString:@"DURATION:" withString:@""] stringByReplacingOccurrencesOfString:@"\r" withString:@""];
         
         // Extract end time
         eventScanner = [NSScanner scannerWithString:event];
@@ -242,6 +249,7 @@
         }
         
         MXLCalendarEvent *event = [[MXLCalendarEvent alloc] initWithStartDate:startDateTimeString
+                                                                     duration:durationString
                                                                       endDate:endDateTimeString
                                                                     createdAt:createdDateTimeString
                                                                  lastModified:lastModifiedDateTimeString

--- a/MXLCalendarManager/NSDateComponents+ISO8601Duration.h
+++ b/MXLCalendarManager/NSDateComponents+ISO8601Duration.h
@@ -1,0 +1,41 @@
+//
+//  NSDateComponents+ISO8601Duration.h
+//  ISO8601Duration
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2014 Kevin Randrup
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+/*
+ * This category converts ISO 8601 duration strings with the format: P[n]Y[n]M[n]DT[n]H[n]M[n]S or P[n]W into date components.
+ * Ex. PT12H = 12 hours
+ * Ex. P3D = 3 days
+ * Ex. P3DT12H = 3 days, 12 hours
+ * Ex. P3Y6M4DT12H30M5S = 3 years, 6 months, 4 days, 12 hours, 30 minutes and 5 seconds
+ * Ex. P10W = 70 days
+ * For more information look here http://en.wikipedia.org/wiki/ISO_8601#Durations
+ * WARNING: The specification allows decimal values which this category does not support. Pull requests are welcome.
+ */
+@interface NSDateComponents (ISO8601Duration)
++ (NSDateComponents *)durationFrom8601String:(NSString *)durationString;
+@end

--- a/MXLCalendarManager/NSDateComponents+ISO8601Duration.m
+++ b/MXLCalendarManager/NSDateComponents+ISO8601Duration.m
@@ -1,0 +1,123 @@
+//
+//  NSDateComponents+ISO8601Duration.m
+//  ISO8601Duration
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2014 Kevin Randrup
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#import "NSDateComponents+ISO8601Duration.h"
+
+@implementation NSDateComponents (ISO8601Duration)
+
+//Note: Does not handle decimal values or overflow values
++ (NSDateComponents *)durationFrom8601String:(NSString *)durationString //Format: PnYnMnDTnHnMnS or PnW
+{
+    NSCharacterSet *timeDesignators = [NSCharacterSet characterSetWithCharactersInString:@"HMS"];
+    NSCharacterSet *periodDesignators = [NSCharacterSet characterSetWithCharactersInString:@"YMD"];
+    
+    NSDateComponents *dateComponents = [NSDateComponents new];
+    NSMutableString *mutableDurationString = [durationString mutableCopy];
+    
+    NSRange pRange = [mutableDurationString rangeOfString:@"P"];
+    if (pRange.location == NSNotFound) {
+        [self logErrorMessage:durationString];
+        return nil;
+    }
+    else {
+        [mutableDurationString deleteCharactersInRange:pRange];
+    }
+    
+    if ([durationString containsString:@"W"]) {
+        NSDictionary *weekValues = [self componentsForString:mutableDurationString fromDesignatorSet:[NSCharacterSet characterSetWithCharactersInString:@"W"]];
+        
+        dateComponents.day = [weekValues[@"W"] doubleValue] * 7; //7 day week specified in ISO 8601 standard
+        return dateComponents;
+    }
+    
+    NSRange tRange = [mutableDurationString rangeOfString:@"T" options:NSLiteralSearch];
+    NSString *periodString = nil;
+    NSString *timeString = nil;
+    if (tRange.location == NSNotFound) {
+        periodString = mutableDurationString;
+    } else {
+        periodString = [mutableDurationString substringToIndex:tRange.location];
+        timeString = [mutableDurationString substringFromIndex:tRange.location+1];
+    }
+    
+//    //Might be faster; needs testing for speed
+//    NSArray *timePeriodSplit = [mutableDurationString componentsSeparatedByString:@"T"];
+//    timeString = [timePeriodSplit lastObject];
+//    periodString = [timePeriodSplit firstObject];
+    
+    //SnMnHn
+    NSDictionary *timeValues = [self componentsForString:timeString fromDesignatorSet:timeDesignators];
+    [timeValues enumerateKeysAndObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(NSString *key, NSString *obj, BOOL *stop) {
+        NSInteger value = [obj integerValue];
+        if ([key isEqualToString:@"S"]) {
+            dateComponents.second = value;
+        } else if ([key isEqualToString:@"M"]) {
+            dateComponents.minute = value;
+        } else if ([key isEqualToString:@"H"]) {
+            dateComponents.hour = value;
+        }
+    }];
+    
+    //DnMnYn
+    NSDictionary *periodValues = [self componentsForString:periodString fromDesignatorSet:periodDesignators];
+    [periodValues enumerateKeysAndObjectsWithOptions:NSEnumerationConcurrent usingBlock:^(NSString *key, NSString *obj, BOOL *stop) {
+        NSInteger value = [obj integerValue];
+        if ([key isEqualToString:@"D"]) {
+            dateComponents.day = value;
+        } else if ([key isEqualToString:@"M"]) {
+            dateComponents.month = value;
+        } else if ([key isEqualToString:@"Y"]) {
+            dateComponents.year = value;
+        }
+    }];
+    
+    return dateComponents;
+}
+
++ (NSDictionary *)componentsForString:(NSString *)string fromDesignatorSet:(NSCharacterSet *)designatorSet
+{
+    if (!string) return nil;
+    static NSCharacterSet *numericalSet = nil;
+    if (!numericalSet) numericalSet = [NSCharacterSet decimalDigitCharacterSet];
+    NSMutableArray *componentValues = [[string componentsSeparatedByCharactersInSet:designatorSet] mutableCopy];
+    NSMutableArray *designatorValues = [[string componentsSeparatedByCharactersInSet:numericalSet] mutableCopy];
+    [componentValues removeObject:@""];
+    [designatorValues removeObject:@""];
+    if (componentValues.count == designatorValues.count) {
+        return [NSDictionary dictionaryWithObjects:componentValues forKeys:designatorValues];
+    } else {
+        NSLog(@"String: %@ has an invalid format.", string);
+        return nil;
+    }
+}
+
++ (void)logErrorMessage:(NSString *)durationString
+{
+    NSLog(@"String: %@ has an invalid format.", durationString);
+    NSLog(@"durationString must have a format of PnYnMnDTnHnMnS or PnW");
+}
+
+@end


### PR DESCRIPTION
Implemented scanning for duration in MXLCalendarManager
Added ISO8601 category to parse duration
Added duration parameter to MXLCalendarEvent which sets the end time
via the start time and duration.
Tested example (My Courseoff schedule):
https://gatech.courseoff.com/share/545385473d307301000c09a9