### PR TITLE
MXLCalendar event gets dates with timezones wrong

### DIFF
--- a/MXLCalendarManager/MXLCalendarEvent.m
+++ b/MXLCalendarManager/MXLCalendarEvent.m
@@ -94,20 +94,34 @@
 }
 
 -(NSDate *)dateFromString:(NSString *)dateString {
-    dateString = [dateString stringByReplacingOccurrencesOfString:@"T" withString:@" "];
-    dateString = [dateString stringByReplacingOccurrencesOfString:@"Z" withString:@""];
+    NSDate *date = nil;
     
-    NSDate *date = [dateFormatter dateFromString:dateString];
+    dateString = [dateString stringByReplacingOccurrencesOfString:@"T" withString:@" "];
+    
+    BOOL containsZone = [string rangeOfString:@"z" options:NSCaseInsensitiveSearch].location != NSNotFound;
+    
+    if (containsZone) {
+        dateFormatter.dateFormat = @"yyyyMMdd HHmmssz";
+    }
+    
+    date = [dateFormatter dateFromString:dateString];
     
     if (!date) {
-        dateFormatter.dateFormat = @"yyyyMMdd";
-        date = [dateFormatter dateFromString:dateString];
-        if (date) {
-            self.eventIsAllDay = TRUE;
+        if (containsZone) {
+            dateFormatter.dateFormat = @"yyyyMMddz";
+        }
+        else {
+            dateFormatter.dateFormat = @"yyyyMMdd";
         }
         
-        dateFormatter.dateFormat = @"yyyyMMdd HHmmss";
+        date = [dateFormatter dateFromString:dateString];
+            
+        if (date) {
+            self.eventIsAllDay = YES;
+        }
     }
+    
+    dateFormatter.dateFormat = @"yyyyMMdd HHmmss";
     
     return date;
 }


### PR DESCRIPTION
E.g. for a string value of 20160316T193000Z it'll take it into the calendar time zone's e.g.(N.Y) while the date is in Greenwich's.