### PR TITLE
Default timezone for calendars without such set

### DIFF
--- a/MXLCalendarManager/MXLCalendarEvent.m
+++ b/MXLCalendarManager/MXLCalendarEvent.m
@@ -64,7 +64,7 @@
 
         // Set up the shared NSDateFormatter instance to convert the strings to NSDate objects
         dateFormatter = [[NSDateFormatter alloc] init];
-        [dateFormatter setTimeZone:([NSTimeZone timeZoneWithName:timezoneID] ? [NSTimeZone timeZoneWithName:timezoneID] : [NSTimeZone timeZoneForSecondsFromGMT:0])];
+        [dateFormatter setTimeZone:([NSTimeZone timeZoneWithName:timezoneID] ?: [NSTimeZone localTimeZone])];
 
         [dateFormatter setDateFormat:@"yyyyMMdd HHmmss"];
 


### PR DESCRIPTION
When the .ics file doesn't contain a timezone, the code creates correct all day event dates only on GMT+0 which is not a case in the US. 
Changed it to default to the user timezone so it will work for the users in the same location as the event.
