### PR TITLE
Fix to method convertToEKEventOnDate. Previously it would overwrite t…

### DIFF
--- a/MXLCalendarManager/MXLCalendarEvent.m
+++ b/MXLCalendarManager/MXLCalendarEvent.m
@@ -708,7 +708,17 @@
     
     NSDateComponents *selectedDayComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear
                                                                               fromDate:date];
-    
+
+    if (self.eventIsAllDay) {
+        [components setDay:[selectedDayComponents day]];
+        [components setMonth:[selectedDayComponents month]];
+        [components setYear:[selectedDayComponents year]];
+
+        [endComponents setDay:[endComponents day]-1];
+        [endComponents setMonth:[endComponents month]];
+        [endComponents setYear:[endComponents year]];
+    }
+
     [selectedDayComponents setMinute:components.minute];
     [selectedDayComponents setHour:components.hour];
     

--- a/MXLCalendarManager/MXLCalendarEvent.m
+++ b/MXLCalendarManager/MXLCalendarEvent.m
@@ -710,13 +710,7 @@
                                                                               fromDate:date];
 
     if (self.eventIsAllDay) {
-        [components setDay:[selectedDayComponents day]];
-        [components setMonth:[selectedDayComponents month]];
-        [components setYear:[selectedDayComponents year]];
-
         [endComponents setDay:[endComponents day]-1];
-        [endComponents setMonth:[endComponents month]];
-        [endComponents setYear:[endComponents year]];
     }
 
     [selectedDayComponents setMinute:components.minute];

--- a/MXLCalendarManager/MXLCalendarEvent.m
+++ b/MXLCalendarManager/MXLCalendarEvent.m
@@ -702,30 +702,37 @@
 - (EKEvent *)convertToEKEventOnDate:(NSDate *)date store:(EKEventStore *)eventStore {
     NSDateComponents *components = [[NSCalendar currentCalendar] components:NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear
                                                                    fromDate:self.eventStartDate];
-
+    
     NSDateComponents *endComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear
                                                                       fromDate:self.eventEndDate];
-
+    
     NSDateComponents *selectedDayComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear
                                                                               fromDate:date];
-
-    [components setDay:[selectedDayComponents day]];
-    [components setMonth:[selectedDayComponents month]];
-    [components setYear:[selectedDayComponents year]];
-
-    [endComponents setDay:[selectedDayComponents day]];
-    [endComponents setMonth:[selectedDayComponents month]];
-    [endComponents setYear:[selectedDayComponents year]];
-
+    
+    [selectedDayComponents setMinute:components.minute];
+    [selectedDayComponents setHour:components.hour];
+    
+    NSDate *startDate = [[NSCalendar currentCalendar] dateFromComponents:components];
+    NSDate *endDate = [[NSCalendar currentCalendar] dateFromComponents:endComponents];
+    NSDate *newDate = [[NSCalendar currentCalendar] dateFromComponents:selectedDayComponents];
+    
+    _Bool newIsStart = [components day] == [selectedDayComponents day] && [components month] == [selectedDayComponents month] && [components year] == [selectedDayComponents year];
+    
+    if (!newIsStart) {
+        NSTimeInterval deltaTime = [newDate timeIntervalSinceDate:date];
+        [startDate dateByAddingTimeInterval:deltaTime];
+        [endDate dateByAddingTimeInterval:deltaTime];
+    }
+    
     EKEvent *event = [EKEvent eventWithEventStore:eventStore];
     [event setTitle:[self eventSummary]];
     [event setNotes:[self eventDescription]];
     [event setLocation:[self eventLocation]];
     [event setAllDay:[self eventIsAllDay]];
-
-    [event setStartDate:[[NSCalendar currentCalendar] dateFromComponents:components]];
-    [event setEndDate:[[NSCalendar currentCalendar] dateFromComponents:endComponents]];
-
+    
+    [event setStartDate:startDate];
+    [event setEndDate:endDate];
+    
     return event;
 }
 


### PR DESCRIPTION
…he endDate with the selected date, causing problems when the endDate was on another day than the startDate. It now checks if the startDate is the same as the selected day and if it's not it adds a time interval equal to the difference between start and selected to both the startDate and endDate. This preserves event duration even when moving it to other dates.
